### PR TITLE
Add BigDecimal, String and Stellar::Price support to offer operation builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 - 2.1.5
 - 2.0.0
 - 1.9.3
-- jruby-1.7.9
+- jruby-1.7.20
 - jruby-head
 script: bundle exec rake travis
 notifications:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Or install it yourself as:
 
 Also requires libsodium. Installable via `brew install libsodium` on OS X.
 
+## Supported Ruby Versions
+
+Please see [travis.yml](.travis.yml) for what versions of ruby are currently tested by our continuous integration system.  Any ruby in that list is officially supported.
+
+### JRuby
+
+It seems as though jruby is particularly slow when it comes to BigDecimal math; the source behind this slowness has not been investigated, but it is something to be aware of.
+
 ## Usage
 
 [Examples are here](examples)

--- a/lib/stellar/operation.rb
+++ b/lib/stellar/operation.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module Stellar
   class Operation
 
@@ -135,7 +137,7 @@ module Stellar
       selling    = Asset.send(*attributes[:selling])
       amount     = attributes[:amount]
       offer_id   = attributes[:offer_id] || 0
-      price      = Price.from_f(attributes[:price])
+      price      = interpret_price(attributes[:price])
 
       op = ManageOfferOp.new({
         buying:     buying,
@@ -154,7 +156,7 @@ module Stellar
       buying     = Asset.send(*attributes[:buying])
       selling    = Asset.send(*attributes[:selling])
       amount     = attributes[:amount]
-      price      = Price.from_f(attributes[:price])
+      price      = interpret_price(attributes[:price])
 
       op = CreatePassiveOfferOp.new({
         buying:     buying,
@@ -282,6 +284,21 @@ module Stellar
       asset    = Stellar::Asset.send(*a[0...-1])
 
       return asset, amount
+    end
+
+
+    def self.interpret_price(price)
+      case price
+      when String
+        bd = BigDecimal.new(price)
+        Price.from_f(bd)
+      when Numeric
+        Price.from_f(price)
+      when Stellar::Price
+        price
+      else
+        raise ArgumentError, "Invalid price type: #{price.class}. Must be String, Numeric, or Stellar::Price"
+      end
     end
   end
 end

--- a/spec/lib/stellar/price_spec.rb
+++ b/spec/lib/stellar/price_spec.rb
@@ -19,7 +19,6 @@ describe Stellar::Price, "#from_f" do
   end
 
   it "works with bigdecimal" do
-    iterations.times do |i|
       whole      = random.rand(1_000_000)
       fractional = random.rand(10_000_000) # seven significant digits available for fractional
       
@@ -30,7 +29,6 @@ describe Stellar::Price, "#from_f" do
       expect(actual).to be_within(BigDecimal.new("0.000000001")).of(actual)
       expect(actual_p.n).to be <= Stellar::Price::MAX_PRECISION
       expect(actual_p.d).to be <= Stellar::Price::MAX_PRECISION
-    end
   end
 
 end

--- a/spec/lib/stellar/price_spec.rb
+++ b/spec/lib/stellar/price_spec.rb
@@ -18,4 +18,19 @@ describe Stellar::Price, "#from_f" do
     end
   end
 
+  it "works with bigdecimal" do
+    iterations.times do |i|
+      whole      = random.rand(1_000_000)
+      fractional = random.rand(10_000_000) # seven significant digits available for fractional
+      
+      expected = BigDecimal.new("#{whole}.#{fractional}")
+      actual_p = subject.from_f(expected)
+      actual = BigDecimal.new(actual_p.n) / BigDecimal.new(actual_p.d) 
+
+      expect(actual).to be_within(BigDecimal.new("0.000000001")).of(actual)
+      expect(actual_p.n).to be <= Stellar::Price::MAX_PRECISION
+      expect(actual_p.d).to be <= Stellar::Price::MAX_PRECISION
+    end
+  end
+
 end


### PR DESCRIPTION
This PR allows a user to avoid floating point arithmetic from user input (string) all the way through to a Stellar::Price structure.
