### PR TITLE
Stellar 0.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: ruby
 rvm:
-- 2.2.0
-- 2.1.5
-- 2.0.0
-- 1.9.3
-- jruby-1.7.20
-- jruby-head
+- 2.2.6
+- 2.3.3
+- 2.4.0
+- jruby
 script: bundle exec rake travis
 notifications:
   slack:
     secure: V/6a8KFe067uukrbCJA2R1HPO4xy0YSQ1pwmHVRi5StX+yl+lYsWWJdjdBdT0j3iJBYyPRqU4bQYck+OloxtELnrHCX+OkodxcxW8W/ACc914iIf0FyY9pnusK7ck2awmt4Iuf94YPgi0XTm1aCcm+f0yU7wiIVFpftoXSk1EDY=
-matrix:
-  allow_failures:
-  - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
 - 2.2.6
 - 2.3.3
 - 2.4.0
-- jruby
 script: bundle exec rake travis
 notifications:
   slack:

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gemspec
 # gem "xdr", path: "../ruby-xdr"
 
 group :development do
-  # gem "xdrgen", git: "https://github.com/stellar/xdrgen.git"
-  gem "xdrgen", path: "../xdrgen"
+  gem "xdrgen", git: "https://github.com/stellar/xdrgen.git"
+  # gem "xdrgen", path: "../xdrgen"
   gem "pry"
   gem "faraday"
   gem "faraday_middleware"

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gemspec
 # gem "xdr", path: "../ruby-xdr"
 
 group :development do
-  gem "xdrgen", git: "https://github.com/stellar/xdrgen.git"
-  # gem "xdrgen", path: "../xdrgen"
+  # gem "xdrgen", git: "https://github.com/stellar/xdrgen.git"
+  gem "xdrgen", path: "../xdrgen"
   gem "pry"
   gem "faraday"
   gem "faraday_middleware"

--- a/generated/stellar-base-generated.rb
+++ b/generated/stellar-base-generated.rb
@@ -13,7 +13,10 @@ module Stellar
   Uint64 = XDR::UnsignedHyper
   Int64 = XDR::Hyper
   autoload :CryptoKeyType
+  autoload :PublicKeyType
+  autoload :SignerKeyType
   autoload :PublicKey
+  autoload :SignerKey
   Signature = XDR::VarOpaque[64]
   SignatureHint = XDR::Opaque[4]
   NodeID = PublicKey
@@ -28,7 +31,9 @@ module Stellar
   AccountID = PublicKey
   Thresholds = XDR::Opaque[4]
   String32 = XDR::String[32]
+  String64 = XDR::String[64]
   SequenceNumber = Uint64
+  DataValue = XDR::VarOpaque[64]
   autoload :AssetType
   autoload :Asset
   autoload :Price
@@ -41,6 +46,7 @@ module Stellar
   autoload :TrustLineEntry
   autoload :OfferEntryFlags
   autoload :OfferEntry
+  autoload :DataEntry
   autoload :LedgerEntry
   autoload :EnvelopeType
 end
@@ -57,11 +63,13 @@ module Stellar
   autoload :SetOptionsOp
   autoload :ChangeTrustOp
   autoload :AllowTrustOp
+  autoload :ManageDataOp
   autoload :Operation
   autoload :MemoType
   autoload :Memo
   autoload :TimeBounds
   autoload :Transaction
+  autoload :TransactionSignaturePayload
   autoload :TransactionEnvelope
   autoload :ClaimOfferAtom
   autoload :CreateAccountResultCode
@@ -86,6 +94,8 @@ module Stellar
   autoload :InflationResultCode
   autoload :InflationPayout
   autoload :InflationResult
+  autoload :ManageDataResultCode
+  autoload :ManageDataResult
   autoload :OperationResultCode
   autoload :OperationResult
   autoload :TransactionResultCode
@@ -102,13 +112,15 @@ module Stellar
   autoload :LedgerKey
   autoload :BucketEntryType
   autoload :BucketEntry
-  MAX_TX_PER_LEDGER = 5000
   autoload :TransactionSet
   autoload :TransactionResultPair
   autoload :TransactionResultSet
   autoload :TransactionHistoryEntry
   autoload :TransactionHistoryResultEntry
   autoload :LedgerHeaderHistoryEntry
+  autoload :LedgerSCPMessages
+  autoload :SCPHistoryEntryV0
+  autoload :SCPHistoryEntry
   autoload :LedgerEntryChangeType
   autoload :LedgerEntryChange
   LedgerEntryChanges = XDR::VarArray[LedgerEntryChange]

--- a/generated/stellar/allow_trust_result_code.rb
+++ b/generated/stellar/allow_trust_result_code.rb
@@ -14,7 +14,8 @@ require 'xdr'
 #       ALLOW_TRUST_NO_TRUST_LINE = -2, // trustor does not have a trustline
 #                                       // source account does not require trust
 #       ALLOW_TRUST_TRUST_NOT_REQUIRED = -3,
-#       ALLOW_TRUST_CANT_REVOKE = -4 // source account can't revoke trust
+#       ALLOW_TRUST_CANT_REVOKE = -4, // source account can't revoke trust,
+#       ALLOW_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
 #   };
 #
 # ===========================================================================
@@ -25,6 +26,7 @@ module Stellar
     member :allow_trust_no_trust_line,      -2
     member :allow_trust_trust_not_required, -3
     member :allow_trust_cant_revoke,        -4
+    member :allow_trust_self_not_allowed,   -5
 
     seal
   end

--- a/generated/stellar/authenticated_message.rb
+++ b/generated/stellar/authenticated_message.rb
@@ -5,18 +5,28 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct AuthenticatedMessage
+#   union AuthenticatedMessage switch (uint32 v)
+#   {
+#   case 0:
+#       struct
 #   {
 #      uint64 sequence;
 #      StellarMessage message;
 #      HmacSha256Mac mac;
+#       } v0;
 #   };
 #
 # ===========================================================================
 module Stellar
-  class AuthenticatedMessage < XDR::Struct
-    attribute :sequence, Uint64
-    attribute :message,  StellarMessage
-    attribute :mac,      HmacSha256Mac
+  class AuthenticatedMessage < XDR::Union
+    include XDR::Namespace
+
+    autoload :V0
+
+    switch_on Uint32, :v
+
+    switch 0, :v0
+
+    attribute :v0, V0
   end
 end

--- a/generated/stellar/authenticated_message/v0.rb
+++ b/generated/stellar/authenticated_message/v0.rb
@@ -5,16 +5,20 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   struct
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
-#   };
+#      uint64 sequence;
+#      StellarMessage message;
+#      HmacSha256Mac mac;
+#       }
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class AuthenticatedMessage
+    class V0 < XDR::Struct
+      attribute :sequence, Uint64
+      attribute :message,  StellarMessage
+      attribute :mac,      HmacSha256Mac
+    end
   end
 end

--- a/generated/stellar/change_trust_result_code.rb
+++ b/generated/stellar/change_trust_result_code.rb
@@ -14,17 +14,19 @@ require 'xdr'
 #       CHANGE_TRUST_NO_ISSUER = -2,     // could not find issuer
 #       CHANGE_TRUST_INVALID_LIMIT = -3, // cannot drop limit below balance
 #                                        // cannot create with a limit of 0
-#       CHANGE_TRUST_LOW_RESERVE = -4 // not enough funds to create a new trust line
+#       CHANGE_TRUST_LOW_RESERVE = -4, // not enough funds to create a new trust line,
+#       CHANGE_TRUST_SELF_NOT_ALLOWED = -5 // trusting self is not allowed
 #   };
 #
 # ===========================================================================
 module Stellar
   class ChangeTrustResultCode < XDR::Enum
-    member :change_trust_success,       0
-    member :change_trust_malformed,     -1
-    member :change_trust_no_issuer,     -2
-    member :change_trust_invalid_limit, -3
-    member :change_trust_low_reserve,   -4
+    member :change_trust_success,          0
+    member :change_trust_malformed,        -1
+    member :change_trust_no_issuer,        -2
+    member :change_trust_invalid_limit,    -3
+    member :change_trust_low_reserve,      -4
+    member :change_trust_self_not_allowed, -5
 
     seal
   end

--- a/generated/stellar/claim_offer_atom.rb
+++ b/generated/stellar/claim_offer_atom.rb
@@ -7,7 +7,7 @@ require 'xdr'
 #
 #   struct ClaimOfferAtom
 #   {
-#       // emited to identify the offer
+#       // emitted to identify the offer
 #       AccountID sellerID; // Account that owns the offer
 #       uint64 offerID;
 #   

--- a/generated/stellar/crypto_key_type.rb
+++ b/generated/stellar/crypto_key_type.rb
@@ -7,13 +7,17 @@ require 'xdr'
 #
 #   enum CryptoKeyType
 #   {
-#       KEY_TYPE_ED25519 = 0
+#       KEY_TYPE_ED25519 = 0,
+#       KEY_TYPE_HASH_TX = 1,
+#       KEY_TYPE_HASH_X = 2
 #   };
 #
 # ===========================================================================
 module Stellar
   class CryptoKeyType < XDR::Enum
     member :key_type_ed25519, 0
+    member :key_type_hash_tx, 1
+    member :key_type_hash_x,  2
 
     seal
   end

--- a/generated/stellar/data_entry.rb
+++ b/generated/stellar/data_entry.rb
@@ -1,0 +1,35 @@
+# This code was automatically generated using xdrgen
+# DO NOT EDIT or your changes may be overwritten
+
+require 'xdr'
+
+# === xdr source ============================================================
+#
+#   struct DataEntry
+#   {
+#       AccountID accountID; // account this data belongs to
+#       string64 dataName;
+#       DataValue dataValue;
+#   
+#       // reserved for future use
+#       union switch (int v)
+#       {
+#       case 0:
+#           void;
+#       }
+#       ext;
+#   };
+#
+# ===========================================================================
+module Stellar
+  class DataEntry < XDR::Struct
+    include XDR::Namespace
+
+    autoload :Ext
+
+    attribute :account_id, AccountID
+    attribute :data_name,  String64
+    attribute :data_value, DataValue
+    attribute :ext,        Ext
+  end
+end

--- a/generated/stellar/data_entry/ext.rb
+++ b/generated/stellar/data_entry/ext.rb
@@ -5,16 +5,20 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
-#   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
-#   };
+#   union switch (int v)
+#       {
+#       case 0:
+#           void;
+#       }
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class DataEntry
+    class Ext < XDR::Union
+      switch_on XDR::Int, :v
+
+      switch 0
+
+    end
   end
 end

--- a/generated/stellar/hello.rb
+++ b/generated/stellar/hello.rb
@@ -9,6 +9,7 @@ require 'xdr'
 #   {
 #       uint32 ledgerVersion;
 #       uint32 overlayVersion;
+#       uint32 overlayMinVersion;
 #       Hash networkID;
 #       string versionStr<100>;
 #       int listeningPort;
@@ -20,13 +21,14 @@ require 'xdr'
 # ===========================================================================
 module Stellar
   class Hello < XDR::Struct
-    attribute :ledger_version,  Uint32
-    attribute :overlay_version, Uint32
-    attribute :network_id,      Hash
-    attribute :version_str,     XDR::String[100]
-    attribute :listening_port,  XDR::Int
-    attribute :peer_id,         NodeID
-    attribute :cert,            AuthCert
-    attribute :nonce,           Uint256
+    attribute :ledger_version,      Uint32
+    attribute :overlay_version,     Uint32
+    attribute :overlay_min_version, Uint32
+    attribute :network_id,          Hash
+    attribute :version_str,         XDR::String[100]
+    attribute :listening_port,      XDR::Int
+    attribute :peer_id,             NodeID
+    attribute :cert,                AuthCert
+    attribute :nonce,               Uint256
   end
 end

--- a/generated/stellar/ledger_entry.rb
+++ b/generated/stellar/ledger_entry.rb
@@ -17,6 +17,8 @@ require 'xdr'
 #           TrustLineEntry trustLine;
 #       case OFFER:
 #           OfferEntry offer;
+#       case DATA:
+#           DataEntry data;
 #       }
 #       data;
 #   

--- a/generated/stellar/ledger_entry/data.rb
+++ b/generated/stellar/ledger_entry/data.rb
@@ -13,6 +13,8 @@ require 'xdr'
 #           TrustLineEntry trustLine;
 #       case OFFER:
 #           OfferEntry offer;
+#       case DATA:
+#           DataEntry data;
 #       }
 #
 # ===========================================================================
@@ -24,10 +26,12 @@ module Stellar
       switch :account,   :account
       switch :trustline, :trust_line
       switch :offer,     :offer
+      switch :data,      :data
 
       attribute :account,    AccountEntry
       attribute :trust_line, TrustLineEntry
       attribute :offer,      OfferEntry
+      attribute :data,       DataEntry
     end
   end
 end

--- a/generated/stellar/ledger_entry_change.rb
+++ b/generated/stellar/ledger_entry_change.rb
@@ -13,6 +13,8 @@ require 'xdr'
 #       LedgerEntry updated;
 #   case LEDGER_ENTRY_REMOVED:
 #       LedgerKey removed;
+#   case LEDGER_ENTRY_STATE:
+#       LedgerEntry state;
 #   };
 #
 # ===========================================================================
@@ -23,9 +25,11 @@ module Stellar
     switch :ledger_entry_created, :created
     switch :ledger_entry_updated, :updated
     switch :ledger_entry_removed, :removed
+    switch :ledger_entry_state,   :state
 
     attribute :created, LedgerEntry
     attribute :updated, LedgerEntry
     attribute :removed, LedgerKey
+    attribute :state,   LedgerEntry
   end
 end

--- a/generated/stellar/ledger_entry_change_type.rb
+++ b/generated/stellar/ledger_entry_change_type.rb
@@ -9,7 +9,8 @@ require 'xdr'
 #   {
 #       LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
 #       LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
-#       LEDGER_ENTRY_REMOVED = 2  // entry was removed from the ledger
+#       LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
+#       LEDGER_ENTRY_STATE = 3    // value of the entry
 #   };
 #
 # ===========================================================================
@@ -18,6 +19,7 @@ module Stellar
     member :ledger_entry_created, 0
     member :ledger_entry_updated, 1
     member :ledger_entry_removed, 2
+    member :ledger_entry_state,   3
 
     seal
   end

--- a/generated/stellar/ledger_entry_type.rb
+++ b/generated/stellar/ledger_entry_type.rb
@@ -9,7 +9,8 @@ require 'xdr'
 #   {
 #       ACCOUNT = 0,
 #       TRUSTLINE = 1,
-#       OFFER = 2
+#       OFFER = 2,
+#       DATA = 3
 #   };
 #
 # ===========================================================================
@@ -18,6 +19,7 @@ module Stellar
     member :account,   0
     member :trustline, 1
     member :offer,     2
+    member :data,      3
 
     seal
   end

--- a/generated/stellar/ledger_key.rb
+++ b/generated/stellar/ledger_key.rb
@@ -26,6 +26,13 @@ require 'xdr'
 #           AccountID sellerID;
 #           uint64 offerID;
 #       } offer;
+#   
+#   case DATA:
+#       struct
+#       {
+#           AccountID accountID;
+#           string64 dataName;
+#       } data;
 #   };
 #
 # ===========================================================================
@@ -36,15 +43,18 @@ module Stellar
     autoload :Account
     autoload :TrustLine
     autoload :Offer
+    autoload :Data
 
     switch_on LedgerEntryType, :type
 
     switch :account,   :account
     switch :trustline, :trust_line
     switch :offer,     :offer
+    switch :data,      :data
 
     attribute :account,    Account
     attribute :trust_line, TrustLine
     attribute :offer,      Offer
+    attribute :data,       Data
   end
 end

--- a/generated/stellar/ledger_key/data.rb
+++ b/generated/stellar/ledger_key/data.rb
@@ -5,16 +5,18 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
-#   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
-#   };
+#   struct
+#       {
+#           AccountID accountID;
+#           string64 dataName;
+#       }
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class LedgerKey
+    class Data < XDR::Struct
+      attribute :account_id, AccountID
+      attribute :data_name,  String64
+    end
   end
 end

--- a/generated/stellar/ledger_scp_messages.rb
+++ b/generated/stellar/ledger_scp_messages.rb
@@ -5,16 +5,16 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   struct LedgerSCPMessages
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
+#       uint32 ledgerSeq;
+#       SCPEnvelope messages<>;
 #   };
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class LedgerSCPMessages < XDR::Struct
+    attribute :ledger_seq, Uint32
+    attribute :messages,   XDR::VarArray[SCPEnvelope]
   end
 end

--- a/generated/stellar/manage_data_op.rb
+++ b/generated/stellar/manage_data_op.rb
@@ -5,16 +5,16 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   struct ManageDataOp
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
+#       string64 dataName; 
+#       DataValue* dataValue;   // set to null to clear
 #   };
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class ManageDataOp < XDR::Struct
+    attribute :data_name,  String64
+    attribute :data_value, XDR::Option[DataValue]
   end
 end

--- a/generated/stellar/manage_data_result.rb
+++ b/generated/stellar/manage_data_result.rb
@@ -5,16 +5,21 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   union ManageDataResult switch (ManageDataResultCode code)
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
+#   case MANAGE_DATA_SUCCESS:
+#       void;
+#   default:
+#       void;
 #   };
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class ManageDataResult < XDR::Union
+    switch_on ManageDataResultCode, :code
+
+    switch :manage_data_success
+    switch :default
+
   end
 end

--- a/generated/stellar/manage_data_result_code.rb
+++ b/generated/stellar/manage_data_result_code.rb
@@ -1,0 +1,30 @@
+# This code was automatically generated using xdrgen
+# DO NOT EDIT or your changes may be overwritten
+
+require 'xdr'
+
+# === xdr source ============================================================
+#
+#   enum ManageDataResultCode
+#   {
+#       // codes considered as "success" for the operation
+#       MANAGE_DATA_SUCCESS = 0,
+#       // codes considered as "failure" for the operation
+#       MANAGE_DATA_NOT_SUPPORTED_YET = -1, // The network hasn't moved to this protocol change yet
+#       MANAGE_DATA_NAME_NOT_FOUND = -2,    // Trying to remove a Data Entry that isn't there
+#       MANAGE_DATA_LOW_RESERVE = -3,       // not enough funds to create a new Data Entry
+#       MANAGE_DATA_INVALID_NAME = -4       // Name not a valid string
+#   };
+#
+# ===========================================================================
+module Stellar
+  class ManageDataResultCode < XDR::Enum
+    member :manage_data_success,           0
+    member :manage_data_not_supported_yet, -1
+    member :manage_data_name_not_found,    -2
+    member :manage_data_low_reserve,       -3
+    member :manage_data_invalid_name,      -4
+
+    seal
+  end
+end

--- a/generated/stellar/message_type.rb
+++ b/generated/stellar/message_type.rb
@@ -8,7 +8,6 @@ require 'xdr'
 #   enum MessageType
 #   {
 #       ERROR_MSG = 0,
-#       HELLO = 1,
 #       AUTH = 2,
 #       DONT_HAVE = 3,
 #   
@@ -23,14 +22,17 @@ require 'xdr'
 #       // SCP
 #       GET_SCP_QUORUMSET = 9,
 #       SCP_QUORUMSET = 10,
-#       SCP_MESSAGE = 11
+#       SCP_MESSAGE = 11,
+#       GET_SCP_STATE = 12,
+#   
+#       // new messages
+#       HELLO = 13
 #   };
 #
 # ===========================================================================
 module Stellar
   class MessageType < XDR::Enum
     member :error_msg,         0
-    member :hello,             1
     member :auth,              2
     member :dont_have,         3
     member :get_peers,         4
@@ -41,6 +43,8 @@ module Stellar
     member :get_scp_quorumset, 9
     member :scp_quorumset,     10
     member :scp_message,       11
+    member :get_scp_state,     12
+    member :hello,             13
 
     seal
   end

--- a/generated/stellar/operation.rb
+++ b/generated/stellar/operation.rb
@@ -34,6 +34,8 @@ require 'xdr'
 #           AccountID destination;
 #       case INFLATION:
 #           void;
+#       case MANAGE_DATA:
+#           ManageDataOp manageDataOp;
 #       }
 #       body;
 #   };

--- a/generated/stellar/operation/body.rb
+++ b/generated/stellar/operation/body.rb
@@ -27,6 +27,8 @@ require 'xdr'
 #           AccountID destination;
 #       case INFLATION:
 #           void;
+#       case MANAGE_DATA:
+#           ManageDataOp manageDataOp;
 #       }
 #
 # ===========================================================================
@@ -45,6 +47,7 @@ module Stellar
       switch :allow_trust,          :allow_trust_op
       switch :account_merge,        :destination
       switch :inflation
+      switch :manage_data,          :manage_data_op
 
       attribute :create_account_op,       CreateAccountOp
       attribute :payment_op,              PaymentOp
@@ -55,6 +58,7 @@ module Stellar
       attribute :change_trust_op,         ChangeTrustOp
       attribute :allow_trust_op,          AllowTrustOp
       attribute :destination,             AccountID
+      attribute :manage_data_op,          ManageDataOp
     end
   end
 end

--- a/generated/stellar/operation_result.rb
+++ b/generated/stellar/operation_result.rb
@@ -30,6 +30,8 @@ require 'xdr'
 #           AccountMergeResult accountMergeResult;
 #       case INFLATION:
 #           InflationResult inflationResult;
+#       case MANAGE_DATA:
+#           ManageDataResult manageDataResult;
 #       }
 #       tr;
 #   default:

--- a/generated/stellar/operation_result/tr.rb
+++ b/generated/stellar/operation_result/tr.rb
@@ -27,6 +27,8 @@ require 'xdr'
 #           AccountMergeResult accountMergeResult;
 #       case INFLATION:
 #           InflationResult inflationResult;
+#       case MANAGE_DATA:
+#           ManageDataResult manageDataResult;
 #       }
 #
 # ===========================================================================
@@ -45,6 +47,7 @@ module Stellar
       switch :allow_trust,          :allow_trust_result
       switch :account_merge,        :account_merge_result
       switch :inflation,            :inflation_result
+      switch :manage_data,          :manage_data_result
 
       attribute :create_account_result,       CreateAccountResult
       attribute :payment_result,              PaymentResult
@@ -56,6 +59,7 @@ module Stellar
       attribute :allow_trust_result,          AllowTrustResult
       attribute :account_merge_result,        AccountMergeResult
       attribute :inflation_result,            InflationResult
+      attribute :manage_data_result,          ManageDataResult
     end
   end
 end

--- a/generated/stellar/operation_type.rb
+++ b/generated/stellar/operation_type.rb
@@ -16,7 +16,8 @@ require 'xdr'
 #       CHANGE_TRUST = 6,
 #       ALLOW_TRUST = 7,
 #       ACCOUNT_MERGE = 8,
-#       INFLATION = 9
+#       INFLATION = 9,
+#       MANAGE_DATA = 10
 #   };
 #
 # ===========================================================================
@@ -32,6 +33,7 @@ module Stellar
     member :allow_trust,          7
     member :account_merge,        8
     member :inflation,            9
+    member :manage_data,          10
 
     seal
   end

--- a/generated/stellar/peer_address.rb
+++ b/generated/stellar/peer_address.rb
@@ -13,7 +13,8 @@ require 'xdr'
 #           opaque ipv4[4];
 #       case IPv6:
 #           opaque ipv6[16];
-#       } ip;
+#       }
+#       ip;
 #       uint32 port;
 #       uint32 numFailures;
 #   };

--- a/generated/stellar/public_key.rb
+++ b/generated/stellar/public_key.rb
@@ -5,18 +5,18 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   union PublicKey switch (CryptoKeyType type)
+#   union PublicKey switch (PublicKeyType type)
 #   {
-#   case KEY_TYPE_ED25519:
+#   case PUBLIC_KEY_TYPE_ED25519:
 #       uint256 ed25519;
 #   };
 #
 # ===========================================================================
 module Stellar
   class PublicKey < XDR::Union
-    switch_on CryptoKeyType, :type
+    switch_on PublicKeyType, :type
 
-    switch :key_type_ed25519, :ed25519
+    switch :public_key_type_ed25519, :ed25519
 
     attribute :ed25519, Uint256
   end

--- a/generated/stellar/public_key_type.rb
+++ b/generated/stellar/public_key_type.rb
@@ -5,16 +5,16 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   enum PublicKeyType
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
+#       PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
 #   };
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class PublicKeyType < XDR::Enum
+    member :public_key_type_ed25519, 0
+
+    seal
   end
 end

--- a/generated/stellar/scp_history_entry.rb
+++ b/generated/stellar/scp_history_entry.rb
@@ -5,16 +5,19 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   union SCPHistoryEntry switch (int v)
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
+#   case 0:
+#       SCPHistoryEntryV0 v0;
 #   };
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class SCPHistoryEntry < XDR::Union
+    switch_on XDR::Int, :v
+
+    switch 0, :v0
+
+    attribute :v0, SCPHistoryEntryV0
   end
 end

--- a/generated/stellar/scp_history_entry_v0.rb
+++ b/generated/stellar/scp_history_entry_v0.rb
@@ -5,16 +5,16 @@ require 'xdr'
 
 # === xdr source ============================================================
 #
-#   struct Signer
+#   struct SCPHistoryEntryV0
 #   {
-#       SignerKey key;
-#       uint32 weight; // really only need 1byte
+#       SCPQuorumSet quorumSets<>; // additional quorum sets used by ledgerMessages
+#       LedgerSCPMessages ledgerMessages;
 #   };
 #
 # ===========================================================================
 module Stellar
-  class Signer < XDR::Struct
-    attribute :key,    SignerKey
-    attribute :weight, Uint32
+  class SCPHistoryEntryV0 < XDR::Struct
+    attribute :quorum_sets,     XDR::VarArray[SCPQuorumSet]
+    attribute :ledger_messages, LedgerSCPMessages
   end
 end

--- a/generated/stellar/scp_statement.rb
+++ b/generated/stellar/scp_statement.rb
@@ -19,24 +19,23 @@ require 'xdr'
 #               SCPBallot ballot;         // b
 #               SCPBallot* prepared;      // p
 #               SCPBallot* preparedPrime; // p'
-#               uint32 nC;                // n_c
-#               uint32 nP;                // n_P
+#               uint32 nC;                // c.n
+#               uint32 nH;                // h.n
 #           } prepare;
 #       case SCP_ST_CONFIRM:
 #           struct
 #           {
+#               SCPBallot ballot;   // b
+#               uint32 nPrepared;   // p.n
+#               uint32 nCommit;     // c.n
+#               uint32 nH;          // h.n
 #               Hash quorumSetHash; // D
-#               uint32 nPrepared;   // n_p
-#               SCPBallot commit;   // c
-#               uint32 nP;          // n_P
 #           } confirm;
 #       case SCP_ST_EXTERNALIZE:
 #           struct
 #           {
-#               SCPBallot commit; // c
-#               uint32 nP;        // n_P
-#               // not from the paper, but useful to build tooling to
-#               // traverse the graph based off only the latest statement
+#               SCPBallot commit;         // c
+#               uint32 nH;                // h.n
 #               Hash commitQuorumSetHash; // D used before EXTERNALIZE
 #           } externalize;
 #       case SCP_ST_NOMINATE:

--- a/generated/stellar/scp_statement/pledges.rb
+++ b/generated/stellar/scp_statement/pledges.rb
@@ -14,24 +14,23 @@ require 'xdr'
 #               SCPBallot ballot;         // b
 #               SCPBallot* prepared;      // p
 #               SCPBallot* preparedPrime; // p'
-#               uint32 nC;                // n_c
-#               uint32 nP;                // n_P
+#               uint32 nC;                // c.n
+#               uint32 nH;                // h.n
 #           } prepare;
 #       case SCP_ST_CONFIRM:
 #           struct
 #           {
+#               SCPBallot ballot;   // b
+#               uint32 nPrepared;   // p.n
+#               uint32 nCommit;     // c.n
+#               uint32 nH;          // h.n
 #               Hash quorumSetHash; // D
-#               uint32 nPrepared;   // n_p
-#               SCPBallot commit;   // c
-#               uint32 nP;          // n_P
 #           } confirm;
 #       case SCP_ST_EXTERNALIZE:
 #           struct
 #           {
-#               SCPBallot commit; // c
-#               uint32 nP;        // n_P
-#               // not from the paper, but useful to build tooling to
-#               // traverse the graph based off only the latest statement
+#               SCPBallot commit;         // c
+#               uint32 nH;                // h.n
 #               Hash commitQuorumSetHash; // D used before EXTERNALIZE
 #           } externalize;
 #       case SCP_ST_NOMINATE:

--- a/generated/stellar/scp_statement/pledges/confirm.rb
+++ b/generated/stellar/scp_statement/pledges/confirm.rb
@@ -7,10 +7,11 @@ require 'xdr'
 #
 #   struct
 #           {
+#               SCPBallot ballot;   // b
+#               uint32 nPrepared;   // p.n
+#               uint32 nCommit;     // c.n
+#               uint32 nH;          // h.n
 #               Hash quorumSetHash; // D
-#               uint32 nPrepared;   // n_p
-#               SCPBallot commit;   // c
-#               uint32 nP;          // n_P
 #           }
 #
 # ===========================================================================
@@ -18,10 +19,11 @@ module Stellar
   class SCPStatement
     class Pledges
       class Confirm < XDR::Struct
-        attribute :quorum_set_hash, Hash
+        attribute :ballot,          SCPBallot
         attribute :n_prepared,      Uint32
-        attribute :commit,          SCPBallot
-        attribute :n_p,             Uint32
+        attribute :n_commit,        Uint32
+        attribute :n_h,             Uint32
+        attribute :quorum_set_hash, Hash
       end
     end
   end

--- a/generated/stellar/scp_statement/pledges/externalize.rb
+++ b/generated/stellar/scp_statement/pledges/externalize.rb
@@ -7,10 +7,8 @@ require 'xdr'
 #
 #   struct
 #           {
-#               SCPBallot commit; // c
-#               uint32 nP;        // n_P
-#               // not from the paper, but useful to build tooling to
-#               // traverse the graph based off only the latest statement
+#               SCPBallot commit;         // c
+#               uint32 nH;                // h.n
 #               Hash commitQuorumSetHash; // D used before EXTERNALIZE
 #           }
 #
@@ -20,7 +18,7 @@ module Stellar
     class Pledges
       class Externalize < XDR::Struct
         attribute :commit,                 SCPBallot
-        attribute :n_p,                    Uint32
+        attribute :n_h,                    Uint32
         attribute :commit_quorum_set_hash, Hash
       end
     end

--- a/generated/stellar/scp_statement/pledges/prepare.rb
+++ b/generated/stellar/scp_statement/pledges/prepare.rb
@@ -11,8 +11,8 @@ require 'xdr'
 #               SCPBallot ballot;         // b
 #               SCPBallot* prepared;      // p
 #               SCPBallot* preparedPrime; // p'
-#               uint32 nC;                // n_c
-#               uint32 nP;                // n_P
+#               uint32 nC;                // c.n
+#               uint32 nH;                // h.n
 #           }
 #
 # ===========================================================================
@@ -25,7 +25,7 @@ module Stellar
         attribute :prepared,        XDR::Option[SCPBallot]
         attribute :prepared_prime,  XDR::Option[SCPBallot]
         attribute :n_c,             Uint32
-        attribute :n_p,             Uint32
+        attribute :n_h,             Uint32
       end
     end
   end

--- a/generated/stellar/signer_key.rb
+++ b/generated/stellar/signer_key.rb
@@ -1,0 +1,31 @@
+# This code was automatically generated using xdrgen
+# DO NOT EDIT or your changes may be overwritten
+
+require 'xdr'
+
+# === xdr source ============================================================
+#
+#   union SignerKey switch (SignerKeyType type)
+#   {
+#   case SIGNER_KEY_TYPE_ED25519:
+#       uint256 ed25519;
+#   case SIGNER_KEY_TYPE_HASH_TX:
+#       Hash hashTx;
+#   case SIGNER_KEY_TYPE_HASH_X:
+#       Hash hashX;
+#   };
+#
+# ===========================================================================
+module Stellar
+  class SignerKey < XDR::Union
+    switch_on SignerKeyType, :type
+
+    switch :signer_key_type_ed25519, :ed25519
+    switch :signer_key_type_hash_tx, :hash_tx
+    switch :signer_key_type_hash_x,  :hash_x
+
+    attribute :ed25519, Uint256
+    attribute :hash_tx, Hash
+    attribute :hash_x,  Hash
+  end
+end

--- a/generated/stellar/signer_key_type.rb
+++ b/generated/stellar/signer_key_type.rb
@@ -1,0 +1,24 @@
+# This code was automatically generated using xdrgen
+# DO NOT EDIT or your changes may be overwritten
+
+require 'xdr'
+
+# === xdr source ============================================================
+#
+#   enum SignerKeyType
+#   {
+#       SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+#       SIGNER_KEY_TYPE_HASH_TX = KEY_TYPE_HASH_TX,
+#       SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X
+#   };
+#
+# ===========================================================================
+module Stellar
+  class SignerKeyType < XDR::Enum
+    member :signer_key_type_ed25519, 0
+    member :signer_key_type_hash_tx, 1
+    member :signer_key_type_hash_x,  2
+
+    seal
+  end
+end

--- a/generated/stellar/stellar_message.rb
+++ b/generated/stellar/stellar_message.rb
@@ -35,6 +35,8 @@ require 'xdr'
 #       SCPQuorumSet qSet;
 #   case SCP_MESSAGE:
 #       SCPEnvelope envelope;
+#   case GET_SCP_STATE:
+#       uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 #   };
 #
 # ===========================================================================
@@ -54,17 +56,19 @@ module Stellar
     switch :get_scp_quorumset, :q_set_hash
     switch :scp_quorumset,     :q_set
     switch :scp_message,       :envelope
+    switch :get_scp_state,     :get_scp_ledger_seq
 
-    attribute :error,       Error
-    attribute :hello,       Hello
-    attribute :auth,        Auth
-    attribute :dont_have,   DontHave
-    attribute :peers,       XDR::VarArray[PeerAddress]
-    attribute :tx_set_hash, Uint256
-    attribute :tx_set,      TransactionSet
-    attribute :transaction, TransactionEnvelope
-    attribute :q_set_hash,  Uint256
-    attribute :q_set,       SCPQuorumSet
-    attribute :envelope,    SCPEnvelope
+    attribute :error,              Error
+    attribute :hello,              Hello
+    attribute :auth,               Auth
+    attribute :dont_have,          DontHave
+    attribute :peers,              XDR::VarArray[PeerAddress]
+    attribute :tx_set_hash,        Uint256
+    attribute :tx_set,             TransactionSet
+    attribute :transaction,        TransactionEnvelope
+    attribute :q_set_hash,         Uint256
+    attribute :q_set,              SCPQuorumSet
+    attribute :envelope,           SCPEnvelope
+    attribute :get_scp_ledger_seq, Uint32
   end
 end

--- a/generated/stellar/time_bounds.rb
+++ b/generated/stellar/time_bounds.rb
@@ -8,7 +8,7 @@ require 'xdr'
 #   struct TimeBounds
 #   {
 #       uint64 minTime;
-#       uint64 maxTime;
+#       uint64 maxTime; // 0 here means no maxTime
 #   };
 #
 # ===========================================================================

--- a/generated/stellar/transaction_envelope.rb
+++ b/generated/stellar/transaction_envelope.rb
@@ -8,7 +8,10 @@ require 'xdr'
 #   struct TransactionEnvelope
 #   {
 #       Transaction tx;
-#       DecoratedSignature signatures<20>;
+#       /* Each decorated signature is a signature over the SHA256 hash of
+#        * a TransactionSignaturePayload */
+#       DecoratedSignature
+#       signatures<20>;
 #   };
 #
 # ===========================================================================

--- a/generated/stellar/transaction_result_set.rb
+++ b/generated/stellar/transaction_result_set.rb
@@ -7,12 +7,12 @@ require 'xdr'
 #
 #   struct TransactionResultSet
 #   {
-#       TransactionResultPair results<MAX_TX_PER_LEDGER>;
+#       TransactionResultPair results<>;
 #   };
 #
 # ===========================================================================
 module Stellar
   class TransactionResultSet < XDR::Struct
-    attribute :results, XDR::VarArray[TransactionResultPair, MAX_TX_PER_LEDGER]
+    attribute :results, XDR::VarArray[TransactionResultPair]
   end
 end

--- a/generated/stellar/transaction_set.rb
+++ b/generated/stellar/transaction_set.rb
@@ -8,13 +8,13 @@ require 'xdr'
 #   struct TransactionSet
 #   {
 #       Hash previousLedgerHash;
-#       TransactionEnvelope txs<MAX_TX_PER_LEDGER>;
+#       TransactionEnvelope txs<>;
 #   };
 #
 # ===========================================================================
 module Stellar
   class TransactionSet < XDR::Struct
     attribute :previous_ledger_hash, Hash
-    attribute :txs,                  XDR::VarArray[TransactionEnvelope, MAX_TX_PER_LEDGER]
+    attribute :txs,                  XDR::VarArray[TransactionEnvelope]
   end
 end

--- a/generated/stellar/transaction_signature_payload.rb
+++ b/generated/stellar/transaction_signature_payload.rb
@@ -1,0 +1,28 @@
+# This code was automatically generated using xdrgen
+# DO NOT EDIT or your changes may be overwritten
+
+require 'xdr'
+
+# === xdr source ============================================================
+#
+#   struct TransactionSignaturePayload {
+#       Hash networkId;
+#       union switch (EnvelopeType type)
+#       {
+#       case ENVELOPE_TYPE_TX:
+#             Transaction tx;
+#       /* All other values of type are invalid */
+#       } taggedTransaction;
+#   };
+#
+# ===========================================================================
+module Stellar
+  class TransactionSignaturePayload < XDR::Struct
+    include XDR::Namespace
+
+    autoload :TaggedTransaction
+
+    attribute :network_id,         Hash
+    attribute :tagged_transaction, TaggedTransaction
+  end
+end

--- a/generated/stellar/transaction_signature_payload/tagged_transaction.rb
+++ b/generated/stellar/transaction_signature_payload/tagged_transaction.rb
@@ -1,0 +1,26 @@
+# This code was automatically generated using xdrgen
+# DO NOT EDIT or your changes may be overwritten
+
+require 'xdr'
+
+# === xdr source ============================================================
+#
+#   union switch (EnvelopeType type)
+#       {
+#       case ENVELOPE_TYPE_TX:
+#             Transaction tx;
+#       /* All other values of type are invalid */
+#       }
+#
+# ===========================================================================
+module Stellar
+  class TransactionSignaturePayload
+    class TaggedTransaction < XDR::Union
+      switch_on EnvelopeType, :type
+
+      switch :envelope_type_tx, :tx
+
+      attribute :tx, Transaction
+    end
+  end
+end

--- a/lib/stellar-base.rb
+++ b/lib/stellar-base.rb
@@ -6,7 +6,6 @@ require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/kernel/reporting'
 
 # See ../generated for code-gen'ed files
-
 silence_warnings do
   require 'stellar-base-generated'
 end

--- a/lib/stellar/key_pair.rb
+++ b/lib/stellar/key_pair.rb
@@ -42,11 +42,11 @@ module Stellar
     end
 
     def account_id
-      Stellar::AccountID.new :key_type_ed25519, raw_public_key
+      Stellar::AccountID.new :public_key_type_ed25519, raw_public_key
     end
 
     def public_key
-      Stellar::PublicKey.new :key_type_ed25519, raw_public_key
+      Stellar::PublicKey.new :public_key_type_ed25519, raw_public_key
     end
 
     def raw_public_key

--- a/lib/stellar/thresholds.rb
+++ b/lib/stellar/thresholds.rb
@@ -14,7 +14,7 @@ module Stellar
       COMPONENTS.each do |c|
         good = true
 
-        good &&= thresholds[c].is_a?(Fixnum)
+        good &&= thresholds[c].is_a?(Integer)
         good &&= VALID_RANGE.include? thresholds[c]
 
         unless good

--- a/ruby-stellar-base.gemspec
+++ b/ruby-stellar-base.gemspec
@@ -1,7 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'stellar/base/version'
+require_relative './lib/stellar/base/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "stellar-base"
@@ -17,12 +15,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["generated", "lib"]
 
-  spec.add_dependency "xdr", "~> 1.0.0"
+  spec.add_dependency "xdr", "~> 2.0.0"
   spec.add_dependency "digest-crc"
   spec.add_dependency "base32"
   spec.add_dependency "rbnacl"
   spec.add_dependency "rbnacl-libsodium", "~> 1.0.3"
-  spec.add_dependency "activesupport", "~> 4"
+  spec.add_dependency "activesupport", ">= 4.2.7"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/lib/stellar/convert_spec.rb
+++ b/spec/lib/stellar/convert_spec.rb
@@ -51,7 +51,7 @@ describe Stellar::Convert do
 
   describe "#pk_to_address" do
     let(:pk_raw){ "\x00" * 32 }
-    let(:pk_account_id){ Stellar::AccountID.new(:key_type_ed25519, pk_raw)}
+    let(:pk_account_id){ Stellar::AccountID.new(:public_key_type_ed25519, pk_raw)}
 
     it "converts a Stellar::AccountID into an address using StrKey.check_encode(:account_id)" do
       address = Stellar::Util::StrKey.check_encode(:account_id, pk_raw)

--- a/spec/lib/stellar/transaction_spec.rb
+++ b/spec/lib/stellar/transaction_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Stellar::Transaction do
   subject do
     Stellar::Transaction.new({
-      source_account: Stellar::AccountID.new(:key_type_ed25519, "\x00" * 32),
+      source_account: Stellar::AccountID.new(:public_key_type_ed25519, "\x00" * 32),
       fee:            10,
       seq_num:        1,
       memo:           Stellar::Memo.new(:memo_none),

--- a/tasks/xdr.rake
+++ b/tasks/xdr.rake
@@ -26,7 +26,7 @@ namespace :xdr do
 
     HAYASHI_XDR.each do |src|
       local_path = "xdr/" + File.basename(src)
-      encoded    = client.contents("stellar/stellar-core", path: src).content
+      encoded    = client.contents("stellar/stellar-core", path: src, ref:"1c2a3fb7a29eedb0c9513132834dd38fee243a63").content
       decoded    = Base64.decode64 encoded
 
       IO.write(local_path, decoded)

--- a/xdr/Stellar-SCP.x
+++ b/xdr/Stellar-SCP.x
@@ -44,24 +44,23 @@ struct SCPStatement
             SCPBallot ballot;         // b
             SCPBallot* prepared;      // p
             SCPBallot* preparedPrime; // p'
-            uint32 nC;                // n_c
-            uint32 nP;                // n_P
+            uint32 nC;                // c.n
+            uint32 nH;                // h.n
         } prepare;
     case SCP_ST_CONFIRM:
         struct
         {
+            SCPBallot ballot;   // b
+            uint32 nPrepared;   // p.n
+            uint32 nCommit;     // c.n
+            uint32 nH;          // h.n
             Hash quorumSetHash; // D
-            uint32 nPrepared;   // n_p
-            SCPBallot commit;   // c
-            uint32 nP;          // n_P
         } confirm;
     case SCP_ST_EXTERNALIZE:
         struct
         {
-            SCPBallot commit; // c
-            uint32 nP;        // n_P
-            // not from the paper, but useful to build tooling to
-            // traverse the graph based off only the latest statement
+            SCPBallot commit;         // c
+            uint32 nH;                // h.n
             Hash commitQuorumSetHash; // D used before EXTERNALIZE
         } externalize;
     case SCP_ST_NOMINATE:

--- a/xdr/Stellar-ledger-entries.x
+++ b/xdr/Stellar-ledger-entries.x
@@ -10,7 +10,9 @@ namespace stellar
 typedef PublicKey AccountID;
 typedef opaque Thresholds[4];
 typedef string string32<32>;
+typedef string string64<64>;
 typedef uint64 SequenceNumber;
+typedef opaque DataValue<64>; 
 
 enum AssetType
 {
@@ -62,12 +64,13 @@ enum LedgerEntryType
 {
     ACCOUNT = 0,
     TRUSTLINE = 1,
-    OFFER = 2
+    OFFER = 2,
+    DATA = 3
 };
 
 struct Signer
 {
-    AccountID pubKey;
+    SignerKey key;
     uint32 weight; // really only need 1byte
 };
 
@@ -190,6 +193,25 @@ struct OfferEntry
     ext;
 };
 
+/* DataEntry
+    Data can be attached to accounts.
+*/
+struct DataEntry
+{
+    AccountID accountID; // account this data belongs to
+    string64 dataName;
+    DataValue dataValue;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
+};
+
+
 struct LedgerEntry
 {
     uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
@@ -202,6 +224,8 @@ struct LedgerEntry
         TrustLineEntry trustLine;
     case OFFER:
         OfferEntry offer;
+    case DATA:
+        DataEntry data;
     }
     data;
 

--- a/xdr/Stellar-overlay.x
+++ b/xdr/Stellar-overlay.x
@@ -33,6 +33,7 @@ struct Hello
 {
     uint32 ledgerVersion;
     uint32 overlayVersion;
+    uint32 overlayMinVersion;
     Hash networkID;
     string versionStr<100>;
     int listeningPort;
@@ -62,7 +63,8 @@ struct PeerAddress
         opaque ipv4[4];
     case IPv6:
         opaque ipv6[16];
-    } ip;
+    }
+    ip;
     uint32 port;
     uint32 numFailures;
 };
@@ -70,7 +72,6 @@ struct PeerAddress
 enum MessageType
 {
     ERROR_MSG = 0,
-    HELLO = 1,
     AUTH = 2,
     DONT_HAVE = 3,
 
@@ -85,7 +86,11 @@ enum MessageType
     // SCP
     GET_SCP_QUORUMSET = 9,
     SCP_QUORUMSET = 10,
-    SCP_MESSAGE = 11
+    SCP_MESSAGE = 11,
+    GET_SCP_STATE = 12,
+
+    // new messages
+    HELLO = 13
 };
 
 struct DontHave
@@ -124,13 +129,18 @@ case SCP_QUORUMSET:
     SCPQuorumSet qSet;
 case SCP_MESSAGE:
     SCPEnvelope envelope;
+case GET_SCP_STATE:
+    uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 };
 
-struct AuthenticatedMessage
+union AuthenticatedMessage switch (uint32 v)
+{
+case 0:
+    struct
 {
    uint64 sequence;
    StellarMessage message;
    HmacSha256Mac mac;
+    } v0;
 };
-
 }

--- a/xdr/Stellar-types.x
+++ b/xdr/Stellar-types.x
@@ -16,13 +16,37 @@ typedef hyper int64;
 
 enum CryptoKeyType
 {
-    KEY_TYPE_ED25519 = 0
+    KEY_TYPE_ED25519 = 0,
+    KEY_TYPE_HASH_TX = 1,
+    KEY_TYPE_HASH_X = 2
 };
 
-union PublicKey switch (CryptoKeyType type)
+enum PublicKeyType
 {
-case KEY_TYPE_ED25519:
+    PUBLIC_KEY_TYPE_ED25519 = KEY_TYPE_ED25519
+};
+
+enum SignerKeyType
+{
+    SIGNER_KEY_TYPE_ED25519 = KEY_TYPE_ED25519,
+    SIGNER_KEY_TYPE_HASH_TX = KEY_TYPE_HASH_TX,
+    SIGNER_KEY_TYPE_HASH_X = KEY_TYPE_HASH_X
+};
+
+union PublicKey switch (PublicKeyType type)
+{
+case PUBLIC_KEY_TYPE_ED25519:
     uint256 ed25519;
+};
+
+union SignerKey switch (SignerKeyType type)
+{
+case SIGNER_KEY_TYPE_ED25519:
+    uint256 ed25519;
+case SIGNER_KEY_TYPE_HASH_TX:
+    Hash hashTx;
+case SIGNER_KEY_TYPE_HASH_X:
+    Hash hashX;
 };
 
 // variable size as the size depends on the signature scheme used


### PR DESCRIPTION
This PR adds basic support for stellar 0.6, updating the XDR definitions and resolving test failures that were introduced.

Notably, a very subtle bug was fixed around the autoloading of the generated XDR constants.  Take note of the change to how we load the `VERSION` constant in the gemspec file.  I leave these notes here for history:

The symptoms: `Stellar::Asset` was missing many class methods that caused load errors
The issue: `require_paths` was not being obeyed.  `lib` was being included into the `$LOAD_PATH` before `generated`.
The solution:  don't manually modify the `$LOAD_PATH` in the gemspec