### PR TITLE
Support creation of trustline with no limit

### DIFF
--- a/lib/stellar/operation.rb
+++ b/lib/stellar/operation.rb
@@ -3,6 +3,7 @@ require 'bigdecimal'
 module Stellar
   class Operation
 
+    MAX_INT64 = 2**63 - 1
 
     #
     # Construct a new Stellar::Operation from the provided
@@ -115,13 +116,14 @@ module Stellar
     #
     # @param [Hash] attributes the attributes to create the operation with
     # @option attributes [Stellar::Currrency] :line the asset to trust
-    # @option attributes [Fixnum] :limit the maximum amount to trust
+    # @option attributes [Fixnum] :limit the maximum amount to trust, defaults to max int64,
+    #                                    if the limit is set to 0 it deletes the trustline.
     #
     # @return [Stellar::Operation] the built operation, containing a
     #                              Stellar::ChangeTrustOp body
     def self.change_trust(attributes={})
       line  = Asset.send(*attributes[:line])
-      limit =interpret_amount(attributes[:limit])
+      limit = attributes.key?(:limit) ? interpret_amount(attributes[:limit]) : MAX_INT64
 
       raise ArgumentError, "Bad :limit #{limit}" unless limit.is_a?(Integer)
 

--- a/ruby-stellar-base.gemspec
+++ b/ruby-stellar-base.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.2.7"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "xdrgen"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "guard-rspec"

--- a/spec/lib/stellar/operation_spec.rb
+++ b/spec/lib/stellar/operation_spec.rb
@@ -28,3 +28,30 @@ describe Stellar::Operation, ".manage_data" do
   end
 
 end
+
+describe Stellar::Operation, ".change_trust" do
+
+  let(:issuer) { Stellar::KeyPair.from_address("GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7") }
+  let(:asset) { Stellar::Asset.alphanum4("USD", issuer) }
+
+  it "creates a ChangeTrustOp" do
+    op = Stellar::Operation.change_trust(line: [:alphanum4, "USD", issuer])
+    expect(op.body.value).to be_an_instance_of(Stellar::ChangeTrustOp)
+    expect(op.body.value.line).to eq(Stellar::Asset.alphanum4("USD", issuer))
+    expect(op.body.value.limit).to eq(9223372036854775807)
+  end
+
+  it "creates a ChangeTrustOp with limit" do
+    op = Stellar::Operation.change_trust(line: [:alphanum4, "USD", issuer], limit: 1234.75)
+    expect(op.body.value).to be_an_instance_of(Stellar::ChangeTrustOp)
+    expect(op.body.value.line).to eq(Stellar::Asset.alphanum4("USD", issuer))
+    expect(op.body.value.limit).to eq(12347500000)
+  end
+
+  it "throws ArgumentError for incorrect limit argument" do
+    expect {
+      Stellar::Operation.change_trust(line: [:alphanum4, "USD", issuer], limit: true)
+    }.to raise_error(ArgumentError)
+  end
+
+end


### PR DESCRIPTION
This PR improves `Stellar::Operation.change_trust` method to use max int64 value as a default trustline limit, similarly to JS and Go SDKs.