### PR TITLE
`Stellar::Operation.change_trust` accepts nil limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
 ## [unreleased](https://github.com/stellar/ruby-stellar-base/compare/v0.15.0...master)
+### Added
+- `Stellar::Operation.change_trust` accepts nil limits and defaults to MAX_INT64
 
 ## [0.15.0](https://github.com/stellar/ruby-stellar-base/compare/v0.14.0...v0.15.0)
 ### Added

--- a/lib/stellar/operation.rb
+++ b/lib/stellar/operation.rb
@@ -130,7 +130,11 @@ module Stellar
         line = Asset.send(*line)
       end
 
-      limit = attributes.key?(:limit) ? interpret_amount(attributes[:limit]) : MAX_INT64
+      limit = if attributes[:limit].nil?
+                MAX_INT64
+              else
+                interpret_amount(attributes[:limit])
+              end
 
       raise ArgumentError, "Bad :limit #{limit}" unless limit.is_a?(Integer)
 

--- a/spec/lib/stellar/operation_spec.rb
+++ b/spec/lib/stellar/operation_spec.rb
@@ -62,6 +62,11 @@ describe Stellar::Operation, ".change_trust" do
     expect(op.body.value.limit).to eq(12347500000)
   end
 
+  it "creates a ChangeTrustOp with nil limit" do
+    op = Stellar::Operation.change_trust(line: [:alphanum4, "USD", issuer], limit: nil)
+    expect(op.body.value.limit).to eq Stellar::Operation::MAX_INT64
+  end
+
   it "throws ArgumentError for incorrect limit argument" do
     expect {
       Stellar::Operation.change_trust(line: [:alphanum4, "USD", issuer], limit: true)


### PR DESCRIPTION
- Defaults to MAX_INT64

Useful when there's a wrapper code that always passes this key, regardless of the value being `nil`.