### PR TITLE
Remove rbnacl from direct dependencies

### DIFF
--- a/ruby-stellar-base.gemspec
+++ b/ruby-stellar-base.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "xdr", "~> 3.0.0"
   spec.add_dependency "digest-crc"
   spec.add_dependency "base32"
-  spec.add_dependency "rbnacl"
   spec.add_dependency "rbnacl-libsodium", "~> 1.0.16"
   spec.add_dependency "activesupport", ">= 5.2.0"
 


### PR DESCRIPTION
Let rbnacl-libsodium require it, as it will also fix potential load errors:

https://github.com/crypto-rb/rbnacl-libsodium/issues/11