### PR TITLE
Incorporate changes from bloom-solutions/ruby-stellar-base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
+dist: xenial
 language: ruby
 rvm:
-- 2.2.6
-- 2.3.3
-- 2.4.0
-- 2.5.1
+- 2.3
+- 2.4
+- 2.5
+- 2.6
+cache: bundler
+addons:
+  apt:
+    packages:
+    - libsodium-dev
 before_install:
-  - sudo add-apt-repository -y ppa:chris-lea/libsodium
-  - sudo apt-get -y update
-  - sudo apt-get install -y libsodium-dev
+  - gem update --system && gem install --no-document bundler
 script: bundle exec rake travis
 notifications:
   slack:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## [0.19.0](https://github.com/stellar/ruby-stellar-base/compare/v0.18.0...v0.19.0)
+### Changed
+- Loosen ActiveSupport to >= 5.0.0
+
 ## [0.18.0](https://github.com/stellar/ruby-stellar-base/compare/v0.17.0...v0.18.0)
 ### Added
 - Update XDR definitions for stellar-core v10.0.0 (introduces Liabilities and other changes to support asset-backed offers as per [CAP-0003 Specification](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0003.md#specification))

--- a/lib/stellar/base/version.rb
+++ b/lib/stellar/base/version.rb
@@ -1,5 +1,5 @@
 module Stellar
   module Base
-    VERSION = "0.18.0"
+    VERSION = "0.19.0"
   end
 end

--- a/lib/stellar/operation.rb
+++ b/lib/stellar/operation.rb
@@ -340,7 +340,7 @@ module Stellar
     def self.interpret_amount(amount)
       case amount
       when String
-        (BigDecimal.new(amount) * Stellar::ONE).floor
+        (BigDecimal(amount) * Stellar::ONE).floor
       when Integer
         amount * Stellar::ONE
       when Numeric

--- a/ruby-stellar-base.gemspec
+++ b/ruby-stellar-base.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "digest-crc"
   spec.add_dependency "base32"
   spec.add_dependency "rbnacl", ">= 6.0"
-  spec.add_dependency "activesupport", ">= 5.2.0"
+  spec.add_dependency "activesupport", ">= 5.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "xdrgen"
   spec.add_development_dependency "rspec", "~> 3.1"

--- a/spec/lib/stellar/price_spec.rb
+++ b/spec/lib/stellar/price_spec.rb
@@ -22,11 +22,11 @@ describe Stellar::Price, "#from_f" do
       whole      = random.rand(1_000_000)
       fractional = random.rand(10_000_000) # seven significant digits available for fractional
       
-      expected = BigDecimal.new("#{whole}.#{fractional}")
+      expected = BigDecimal("#{whole}.#{fractional}")
       actual_p = subject.from_f(expected)
-      actual = BigDecimal.new(actual_p.n) / BigDecimal.new(actual_p.d) 
+      actual = BigDecimal(actual_p.n) / BigDecimal(actual_p.d)
 
-      expect(actual).to be_within(BigDecimal.new("0.000000001")).of(actual)
+      expect(actual).to be_within(BigDecimal("0.000000001")).of(actual)
       expect(actual_p.n).to be <= Stellar::Price::MAX_PRECISION
       expect(actual_p.d).to be <= Stellar::Price::MAX_PRECISION
   end


### PR DESCRIPTION
As discussed in stellar/ruby-stellar-sdk#55, this PR incorporates recent changes from bloom-solutions/ruby-stellar-base in order to prepare the proper transfer of this repo to bloom-solutions organization.

I went with manual cherry-picking + some minor fixes along the way, because there're some  inconsistencies in the changelog and versions.

/cc @ramontayag @theaeolianmachine 