### PR TITLE
Use xdrgen from rubygems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-# gem "xdr", git: "https://github.com/stellar/ruby-xdr.git"
-# gem "xdr", path: "../ruby-xdr"
-
 group :development do
-  gem "xdrgen", git: "https://github.com/stellar/xdrgen.git"
-  # gem "xdrgen", path: "../xdrgen"
   gem "pry"
   gem "faraday"
   gem "faraday_middleware"
 end
-


### PR DESCRIPTION
Before this, we were using a branch which doesn't exist any
more. `xdrgen` is now available as a gem, we can rely on it which is
defined in the gemspec.